### PR TITLE
Make datadog optional

### DIFF
--- a/lib/marathon-autoscaler/__main__.py
+++ b/lib/marathon-autoscaler/__main__.py
@@ -63,11 +63,11 @@ def parse_cli_args():
                    default=None, required=False,
                    help="Number of subprocesses to use for gathering and sending stats to Datadog")
     p.add_argument("--dd-api-key", dest="datadog_api_key", action=EnvDefault, envvar="DATADOG_API_KEY", type=str,
-                   required=True, help="Datadog API key")
+                   required=False, help="Datadog API key")
     p.add_argument("--dd-app-key", dest="datadog_app_key", action=EnvDefault, envvar="DATADOG_APP_KEY", type=str,
-                   required=True, help="Datadog APP key")
+                   required=False, help="Datadog APP key")
     p.add_argument("--dd-env", dest="datadog_env", action=EnvDefault, envvar="DATADOG_ENV", type=str,
-                   required=True, help="Datadog ENV variable")
+                   required=False, help="Datadog ENV variable")
     p.add_argument("--log-config", dest="log_config", action=EnvDefault, envvar="LOG_CONFIG", type=str,
                    default="/app/logging_config.json",
                    help="Path to logging configuration file")

--- a/lib/marathon-autoscaler/datadog_metrics.py
+++ b/lib/marathon-autoscaler/datadog_metrics.py
@@ -6,13 +6,16 @@ from datadog import initialize, api
 class DatadogClient:
 
     def __init__(self, cli_args, logger=None):
-        self.dd_auth = dict(api_key=cli_args.datadog_api_key,
-                            app_key=cli_args.datadog_app_key)
-        self.dd_env = cli_args.datadog_env
-        self.cpu_fan_out = cli_args.cpu_fan_out
-        self.logger = logger or logging.getLogger(__name__)
-
-        initialize(**self.dd_auth)
+        if cli_args.datadog_api_key and cli_args.datadog_app_key:
+            self.dd_auth = dict(api_key=cli_args.datadog_api_key,
+                                app_key=cli_args.datadog_app_key)
+            self.dd_env = cli_args.datadog_env
+            self.cpu_fan_out = cli_args.cpu_fan_out
+            self.logger = logger or logging.getLogger(__name__)
+            self.enabled = True
+            initialize(**self.dd_auth)
+        else:
+            self.enabled = False
 
     def send_datadog_metrics(self, stats):
         """ Enumerates metrics from stats object to send to Datadog
@@ -20,59 +23,60 @@ class DatadogClient:
         :return: None
         """
         try:
-            metrics = []
-            for app, items in stats.items():
-                tags = ["env:{}".format(self.dd_env),
-                        "app:{}".format(app)]
+            if self.enabled:
+                metrics = []
+                for app, items in stats.items():
+                    tags = ["env:{}".format(self.dd_env),
+                            "app:{}".format(app)]
 
-                # Avg CPU for entire app
-                metrics.append(dict(metric='marathon.app.cpu_avg',
-                                    points=items['cpu_avg_usage'],
-                                    host='n/a',
-                                    tags=tags))
+                    # Avg CPU for entire app
+                    metrics.append(dict(metric='marathon.app.cpu_avg',
+                                        points=items['cpu_avg_usage'],
+                                        host='n/a',
+                                        tags=tags))
 
-                # Avg mem for entire app
-                metrics.append(dict(metric='marathon.app.mem_avg',
-                                    points=items['memory_avg_usage'],
-                                    host='n/a',
-                                    tags=tags))
+                    # Avg mem for entire app
+                    metrics.append(dict(metric='marathon.app.mem_avg',
+                                        points=items['memory_avg_usage'],
+                                        host='n/a',
+                                        tags=tags))
 
-                tags = ["env:{}".format(self.dd_env),
-                        "app:{}".format(app),
-                        "executor:{}".format(items['max_cpu'][1])]
-
-                # Max CPU for entire app
-                metrics.append(dict(metric='marathon.app.cpu_max',
-                                    points=items['max_cpu'][0],
-                                    host='n/a',
-                                    tags=tags))
-
-                # Max mem for entire app
-                tags = ["env:{}".format(self.dd_env),
-                        "app:{}".format(app),
-                        "executor:{}".format(items['max_memory'][1])]
-
-                metrics.append(dict(metric='marathon.app.mem_max',
-                                    points=items['max_memory'][0],
-                                    host='n/a',
-                                    tags=tags))
-
-                # Per-executor metrics
-                for item in items['executor_metrics']:
                     tags = ["env:{}".format(self.dd_env),
                             "app:{}".format(app),
-                            "executor:{}".format(item['executor_id'])]
+                            "executor:{}".format(items['max_cpu'][1])]
 
-                    metrics.append(dict(metric='marathon.executor.cpu',
-                                        points=item['cpu_total_usage'],
-                                        host=item['host'],
-                                        tags=tags))
-                    metrics.append(dict(metric='marathon.executor.mem',
-                                        points=item['memory_total_usage'],
-                                        host=item['host'],
+                    # Max CPU for entire app
+                    metrics.append(dict(metric='marathon.app.cpu_max',
+                                        points=items['max_cpu'][0],
+                                        host='n/a',
                                         tags=tags))
 
-            api.Metric.send(metrics=metrics)
+                    # Max mem for entire app
+                    tags = ["env:{}".format(self.dd_env),
+                            "app:{}".format(app),
+                            "executor:{}".format(items['max_memory'][1])]
+
+                    metrics.append(dict(metric='marathon.app.mem_max',
+                                        points=items['max_memory'][0],
+                                        host='n/a',
+                                        tags=tags))
+
+                    # Per-executor metrics
+                    for item in items['executor_metrics']:
+                        tags = ["env:{}".format(self.dd_env),
+                                "app:{}".format(app),
+                                "executor:{}".format(item['executor_id'])]
+
+                        metrics.append(dict(metric='marathon.executor.cpu',
+                                            points=item['cpu_total_usage'],
+                                            host=item['host'],
+                                            tags=tags))
+                        metrics.append(dict(metric='marathon.executor.mem',
+                                            points=item['memory_total_usage'],
+                                            host=item['host'],
+                                            tags=tags))
+
+                api.Metric.send(metrics=metrics)
         except Exception as err:
             self.logger.error(err)
 
@@ -88,18 +92,19 @@ class DatadogClient:
         :param kwargs: kwargs for additional future input
         :return: None
         """
-        all_tags = ["env:{}".format(self.dd_env), "app:{}".format(app)]
+        if self.enabled:
+            all_tags = ["env:{}".format(self.dd_env), "app:{}".format(app)]
 
-        if tags:
-            all_tags = tags + all_tags
+            if tags:
+                all_tags = tags + all_tags
 
-        try:
-            api.Metric.send(metric=metric,
-                            points=points if points else 1,
-                            tags=all_tags,
-                            type='counter')
-        except Exception as err:
-            self.logger.error(err)
+            try:
+                api.Metric.send(metric=metric,
+                                points=points if points else 1,
+                                tags=all_tags,
+                                type='counter')
+            except Exception as err:
+                self.logger.error(err)
 
     def send_scale_event(self, app, factor, direction, tags=None):
         """
@@ -111,19 +116,20 @@ class DatadogClient:
         :param tags: datadog tags for categorization
         :return: None
         """
-        all_tags = ["env:{}".format(self.dd_env), "app:{}".format(app)]
+        if self.enabled:
+            all_tags = ["env:{}".format(self.dd_env), "app:{}".format(app)]
 
-        if tags:
-            all_tags = tags + all_tags
-        metrics = {
-                    1: "marathon_autoscaler.events.scale_up",
-                    -1: "marathon_autoscaler.events.scale_down",
-                    0: "marathon_autoscaler.events.idle"
-                  }
-        try:
-            api.Metric.send(metric=metrics[direction],
-                            points=factor,
-                            tags=all_tags,
-                            type='counter')
-        except Exception as err:
-            self.logger.error(err)
+            if tags:
+                all_tags = tags + all_tags
+            metrics = {
+                        1: "marathon_autoscaler.events.scale_up",
+                        -1: "marathon_autoscaler.events.scale_down",
+                        0: "marathon_autoscaler.events.idle"
+                      }
+            try:
+                api.Metric.send(metric=metrics[direction],
+                                points=factor,
+                                tags=all_tags,
+                                type='counter')
+            except Exception as err:
+                self.logger.error(err)


### PR DESCRIPTION
If the datadog_api_key and datadog_app_key are present in CLI arguments, then DatadogClient is enabled; otherwise do nothing.
