### PR TITLE
Tests for History Manager

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 python:
   - "2.7"
   - "3.5"
-  - "3.6-dev"
-  - "nightly"
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to run tests

--- a/lib/marathon_autoscaler/history_manager.py
+++ b/lib/marathon_autoscaler/history_manager.py
@@ -95,7 +95,7 @@ class HistoryManager(object):
         self.logger.info(msg.format(**locals()))
 
         dmsg = "{app_name}: {past_events}"
-        self.logger.debug(msg.format(**locals()))
+        self.logger.debug(dmsg.format(**locals()))
 
         return result
 
@@ -129,7 +129,7 @@ class HistoryManager(object):
         msg = "{app_name}: tolerance reached: {result} / {go_back_this_far:%H:%M:%S.%f} - " \
               "{right_now:%H:%M:%S.%f}"
         self.logger.info(msg.format(**locals()))
-        dmsg = "{app_name}: vote_list: {vote_list}"
+        dmsg = "{app_name}: vote_list: {vote_list}; tolerance: {tolerance}; right_now: {right_now}; time_difference: {time_difference}; go_back_this_far: {go_back_this_far};"
         self.logger.debug(dmsg.format(**locals()))
         return result
 
@@ -153,7 +153,7 @@ class HistoryManager(object):
         msg = "{app_name}: within backoff window: {result} / {go_back_this_far:%H:%M:%S.%f} - " \
               "{right_now:%H:%M:%S.%f}"
         self.logger.info(msg.format(**locals()))
-        dmsg = "{app_name}: {scale_events}"
+        dmsg = "{app_name}: scale events: {scale_events}"
         self.logger.debug(dmsg.format(**locals()))
         return result
 

--- a/tests/simulation_data/app_recommendations.json
+++ b/tests/simulation_data/app_recommendations.json
@@ -1,0 +1,100 @@
+{
+  "recommendationsList": [
+    {
+      "test-service": {
+        "vote": 1,
+        "checksum": "2000-01-01T00:00:01.000Z",
+        "timestamp": "current_date",
+        "rule": {
+          "ruleInfo": {
+            "rulePart": "1",
+            "ruleName": "fastcpuscaleup"
+          },
+          "ruleValue": {
+            "scale_factor": "3",
+            "weight": 1.0,
+            "threshold": {
+              "val": "10",
+              "op": ">"
+            },
+            "metric": "cpu",
+            "tolerance": "PT10S",
+            "backoff": "PT30S"
+          }
+        }
+      }
+    },
+    {
+      "test-service": {
+        "vote": 1,
+        "checksum": "2000-01-01T00:00:01.000Z",
+        "timestamp": "current_date",
+        "rule": {
+          "ruleInfo": {
+            "rulePart": "1",
+            "ruleName": "fastcpuscaleup"
+          },
+          "ruleValue": {
+            "scale_factor": "3",
+            "weight": 1.0,
+            "threshold": {
+              "val": "10",
+              "op": ">"
+            },
+            "metric": "cpu",
+            "tolerance": "PT10S",
+            "backoff": "PT30S"
+          }
+        }
+      }
+    },
+    {
+      "test-service": {
+        "vote": 1,
+        "checksum": "2000-01-01T00:00:01.000Z",
+        "timestamp": "current_date",
+        "rule": {
+          "ruleInfo": {
+            "rulePart": "1",
+            "ruleName": "fastcpuscaleup"
+          },
+          "ruleValue": {
+            "scale_factor": "3",
+            "weight": 1.0,
+            "threshold": {
+              "val": "10",
+              "op": ">"
+            },
+            "metric": "cpu",
+            "tolerance": "PT10S",
+            "backoff": "PT30S"
+          }
+        }
+      }
+    },
+    {
+      "test-service": {
+        "vote": 1,
+        "checksum": "2000-01-01T00:00:01.000Z",
+        "timestamp": "current_date",
+        "rule": {
+          "ruleInfo": {
+            "rulePart": "1",
+            "ruleName": "fastcpuscaleup"
+          },
+          "ruleValue": {
+            "scale_factor": "3",
+            "weight": 1.0,
+            "threshold": {
+              "val": "10",
+              "op": ">"
+            },
+            "metric": "cpu",
+            "tolerance": "PT10S",
+            "backoff": "PT30S"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_history_manager.py
+++ b/tests/test_history_manager.py
@@ -1,13 +1,18 @@
 import os
 import sys
 import json
-
+import dateutil.parser
+from datetime import timedelta, datetime
 import pytest
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
 
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "lib", "marathon_autoscaler"))
 from history_manager import HistoryManager
 import settings
 
+rightnow = datetime.now()
 
 @pytest.fixture(scope="session")
 def testsettings():
@@ -34,3 +39,61 @@ def history_mgr(testsettings):
     _history_mgr = HistoryManager()
     assert (type(_history_mgr) is HistoryManager)
     return _history_mgr
+
+
+def datetime_parser(obj):
+    for k, v in obj.items():
+        if "timestamp" in k:
+            try:
+                obj[k] = rightnow
+            except ValueError as ve:
+                pass
+    return obj
+
+_counter = 1
+
+
+def _decrement_time(date_time, time_span):
+    new_date_time = date_time - timedelta(seconds=time_span * _counter)
+    global _counter
+    _counter += 1
+    return new_date_time
+
+
+@pytest.fixture(scope="session")
+def app_recommendations():
+    with open(
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "simulation_data/app_recommendations.json"
+            ), "r") as f:
+        test_app_recommendations = json.load(f, object_hook=datetime_parser)
+    return test_app_recommendations.get("recommendationsList")
+
+
+def test_add_to_perf_tail(history_mgr, app_recommendations):
+    for recommendation in app_recommendations:
+        history_mgr.add_to_perf_tail(recommendation)
+    assert len(history_mgr.app_performance_tail) > 1
+
+
+def test_tolerance_reached(history_mgr):
+    [event.update({"timestamp": _decrement_time(event.get("timestamp"), 6)})
+     for recommendation in history_mgr.app_performance_tail
+     for app, event in recommendation.items()]
+
+    assert history_mgr.tolerance_reached("test-service", "PT10S", 1)
+
+
+def test_within_backoff(history_mgr):
+    assert not history_mgr.within_backoff("test-service", "PT2M", 1)
+
+
+def test_is_time_window_filled(history_mgr):
+    rightnow = datetime.now()
+    assert history_mgr.is_time_window_filled("test-service", rightnow - timedelta(seconds=10))
+
+
+def test_get_timedelta(history_mgr):
+    timespan_obj = history_mgr.get_timedelta("PT3M34S")
+    assert timespan_obj.seconds == 214

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps=
   pycodestyle
 
 commands=
-  py.test --cov={toxinidir}/lib/marathon-autoscaler/ --junitxml=junit-{envname}.xml \
+  py.test --cov={toxinidir}/lib/marathon_autoscaler/ -s --junitxml=junit-{envname}.xml \
         {posargs}
 
 [pycodestyle]


### PR DESCRIPTION
Adds tests for history_manager and extra logging in the history_manager. Tox config modified to allow application logging to show while running pytests.