### PR TITLE
Getting the exact apps by id...

### DIFF
--- a/lib/marathon_autoscaler/poller.py
+++ b/lib/marathon_autoscaler/poller.py
@@ -144,7 +144,7 @@ class Poller:
 
             metric_sums["executor_metrics"] = metrics
             metric_sums["application_definition"] = next((appdef for appdef in marathon_apps
-                                                          if app.replace("_", "/") in appdef.get("id")), {})
+                                                          if app.replace("_", "/") == appdef.get("id")), {})
             app_metric_summation[app] = metric_sums
 
         return app_metric_summation


### PR DESCRIPTION
Changes the query for the application definition in the list of app definitions to be exact with `app == appdef.id` instead of `app in appdef.id`.

This is a fix for issue #24 