### PR TITLE
Amend documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ The aim of this project is to allow Marathon applications to scale to meet load 
 
 ## Build and deploy the Autoscaler
 
-The Makefile requires REGISTRY environment variable to be set to your Docker registry. 
+The Makefile requires REGISTRY environment variable to be set to your Docker registry.
 
 ```bash
 REGISTRY=fooreg.mydockerregistry.com make
 ```
 
-To manually build the app, the following commands build and deploy the Autoscaler Docker container: 
+To manually build the app, the following commands build and deploy the Autoscaler Docker container:
 
 Build the python zipapp:
 
@@ -52,7 +52,7 @@ docker push {{registry_url}}/marathon_autoscaler:latest
 
 ### Deploying the Autoscaler to Marathon
 
-In the `scripts` directory, deploy_autoscaler_to_marathon.py can be executed to deploy an 
+In the `scripts` directory, deploy_autoscaler_to_marathon.py can be executed to deploy an
 instance of the Autoscaler to your Marathon system. The parameters needed are explained below:
 
 
@@ -62,7 +62,7 @@ instance of the Autoscaler to your Marathon system. The parameters needed are ex
 | --mesos-uri | MESOS_URI | The Mesos HTTP endpoint |
 | --mesos-agent-port | AGENT_PORT | The port your Mesos Agent is listening on (defaults to 5051) |
 | --marathon-uri | MARATHON_URI | The Marathon HTTP endpoint |
-| --marathon-user | MARATHON_USER | The Marathon username for authentication on the `marathon-uri` | 
+| --marathon-user | MARATHON_USER | The Marathon username for authentication on the `marathon-uri` |
 | --marathon-pass | MARATHON_PASS | The Marathon password for authentication on the `marathon-uri` |
 | --cpu-fan-out | CPU_FAN_OUT | Number of subprocesses to use for gathering and sending stats to Datadog |
 | --dd-api-key | DATADOG_API_KEY | Datadog API key |
@@ -78,7 +78,7 @@ cd scripts && python deploy_autoscaler_to_marathon.py {PARAMETERS}
 ```
 
 
-### Deploying a Marathon application to use the Autoscaler 
+### Deploying a Marathon application to use the Autoscaler
 
 #### Participation
 
@@ -103,7 +103,7 @@ Number of minimum and maximum number of application instances.
 ...
 ```
 
-#### Scaling Rules 
+#### Scaling Rules
 
 Scaling rules are set in a Marathon application's labels in its application definition. To get you introduced to scaling rules, let's jump right into an example:
 ```json
@@ -162,10 +162,10 @@ Perhaps you want your application to scale up and down differently for different
 ...
 ```
 When multiple rules focus on the same metric, the autoscaler should take the action of the rule that matches closest to the given tolerance and threshold. It is possible that your application may never trigger some rules depending on the application's behavior.
- 
+
 
 \* Comparisons can use >, <, <=, >=, = or ==
- 
+
 \*\* [A Wikipedia Reference on ISO8601 time duration](https://en.wikipedia.org/wiki/ISO_8601#Durations)
 
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ To complete the example above, so it contains scale down rules, here is example 
 "labels": {
 	"mas_rule_fastscaleup_1": "cpu | >90 | PT2M | 3 | PT1M30S",
 	"mas_rule_fastscaleup_2": "mem | >85 | PT2M | 3 | PT1M30S",
-	"mas_rule_slowscaledown_1": "cpu | <=90 | PT1M | 1 | PT30S",
-	"mas_rule_slowscaledown_2": "mem | <=85 | PT1M | 1 | PT30S"
+	"mas_rule_slowscaledown_1": "cpu | <=90 | PT1M | -1 | PT30S",
+	"mas_rule_slowscaledown_2": "mem | <=85 | PT1M | -1 | PT30S"
 },
 ...
 ```
@@ -144,7 +144,7 @@ Maybe your application is only interested in scaling based on CPU:
 ...
 "labels": {
 	"mas_rule_fastscaleup": "cpu | >90 | PT2M | 3 | PT1M30S",
-	"mas_rule_slowscaledown": "cpu | <=90 | PT1M | 1 | PT30S",
+	"mas_rule_slowscaledown": "cpu | <=90 | PT1M | -1 | PT30S",
 },
 ...
 ```
@@ -156,8 +156,8 @@ Perhaps you want your application to scale up and down differently for different
 	"mas_rule_slowscaleup": "cpu | >40 | PT2M | 1 | PT1M30S",
 	"mas_rule_fastscaleup": "cpu | >60 | PT1M | 3 | PT30S",
 	"mas_rule_hyperscaleup": "cpu | >90 | PT1M | 5 | PT15S",
-	"mas_rule_slowscaledown": "cpu | <90 | PT1M30S | 1 | PT30S",
-	"mas_rule_fastscaledown": "cpu | <10 | PT3M | 5 | PT30S",
+	"mas_rule_slowscaledown": "cpu | <90 | PT1M30S | -1 | PT30S",
+	"mas_rule_fastscaledown": "cpu | <10 | PT3M | -5 | PT30S",
 },
 ...
 ```


### PR DESCRIPTION
Currently, the README examples for scale-down rules have positive numbers in the scaling factor. However, we are experiencing that scale-down rules with positive factors result in undesired scaling up.

This documentation change is supported by:
https://github.com/tendrilinc/marathon-autoscaler/blob/master/tests/simulation_data/app_definition.json#L61-L62
and
https://github.com/tendrilinc/marathon-autoscaler/blob/master/lib/marathon_autoscaler/scaler.py#L36